### PR TITLE
Tune unpacking in `getPassPluginInfo()` lambda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-fvisibility-inlines-hidden" SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG)
-if (${SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG} EQUAL "1")
+if (SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden")
 endif()
 

--- a/lib/AMDGCNMemTrace.cpp
+++ b/lib/AMDGCNMemTrace.cpp
@@ -95,7 +95,7 @@ bool AMDGCNMemTrace::runOnModule(Module &M) {
 
 PassPluginLibraryInfo getPassPluginInfo() {
   const auto callback = [](PassBuilder &PB) {
-    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, auto&&... args) {
+    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, OptimizationLevel Level, ThinOrFullLTOPhase Phase) {
         MPM.addPass(AMDGCNMemTrace());
       return true;
     });

--- a/lib/AMDGCNMemTrace.cpp
+++ b/lib/AMDGCNMemTrace.cpp
@@ -95,7 +95,7 @@ bool AMDGCNMemTrace::runOnModule(Module &M) {
 
 PassPluginLibraryInfo getPassPluginInfo() {
   const auto callback = [](PassBuilder &PB) {
-    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, OptimizationLevel OL, ThinOrFullLTOPhase Phase) {
+    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, auto&&... args) {
         MPM.addPass(AMDGCNMemTrace());
       return true;
     });

--- a/lib/AMDGCNMemTrace.cpp
+++ b/lib/AMDGCNMemTrace.cpp
@@ -95,7 +95,7 @@ bool AMDGCNMemTrace::runOnModule(Module &M) {
 
 PassPluginLibraryInfo getPassPluginInfo() {
   const auto callback = [](PassBuilder &PB) {
-    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, auto) {
+    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, OptimizationLevel OL, ThinOrFullLTOPhase Phase) {
         MPM.addPass(AMDGCNMemTrace());
       return true;
     });

--- a/lib/AMDGCNNumCacheLines.cpp
+++ b/lib/AMDGCNNumCacheLines.cpp
@@ -105,7 +105,7 @@ bool AMDGCNMemTrace::runOnModule(Module &M) {
 
 PassPluginLibraryInfo getPassPluginInfo() {
   const auto callback = [](PassBuilder &PB) {
-    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, auto&&... args) {
+    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, OptimizationLevel Level, ThinOrFullLTOPhase Phase) {
         MPM.addPass(AMDGCNMemTrace());
       return true;
     });

--- a/lib/AMDGCNNumCacheLines.cpp
+++ b/lib/AMDGCNNumCacheLines.cpp
@@ -32,7 +32,6 @@ std::string LoadOrStoreMap(const BasicBlock::iterator &I){
 template <typename LoadOrStoreInst> 
 void InjectingInstrumentationFunction(const BasicBlock::iterator &I, const Function &F, const llvm::Module &M,
 				      uint32_t &LocationCounter){
-	auto &CTX = M.getContext();
 	auto LSI = dyn_cast<LoadOrStoreInst>(I);
 	if (not LSI) return;
 	IRBuilder<> Builder(dyn_cast<Instruction>(I));
@@ -57,7 +56,7 @@ void InjectingInstrumentationFunction(const BasicBlock::iterator &I, const Funct
 	
 //        Function *InstrumentationFunction = M.getFunction("_Z8memTracePvj");
 //        Builder.CreateCall(FunctionType::get(Type::getVoidTy(CTX), {Addr->getType(), Type::getInt32Ty(CTX)} ,false), InstrumentationFunction, {Addr, Builder.getInt32(LocationCounterSourceMap[SourceAndAddrSpaceInfo])});
-	  Type* dataType;
+	  Type* dataType = nullptr;
 	  if (LoadInst* LI = dyn_cast<LoadInst>(I))
 		  dataType=LI->getType();
 	  else if (StoreInst* SI = dyn_cast<StoreInst>(I))

--- a/lib/AMDGCNNumCacheLines.cpp
+++ b/lib/AMDGCNNumCacheLines.cpp
@@ -106,7 +106,7 @@ bool AMDGCNMemTrace::runOnModule(Module &M) {
 
 PassPluginLibraryInfo getPassPluginInfo() {
   const auto callback = [](PassBuilder &PB) {
-    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, auto) {
+    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, OptimizationLevel OL, ThinOrFullLTOPhase Phase) {
         MPM.addPass(AMDGCNMemTrace());
       return true;
     });

--- a/lib/AMDGCNNumCacheLines.cpp
+++ b/lib/AMDGCNNumCacheLines.cpp
@@ -106,7 +106,7 @@ bool AMDGCNMemTrace::runOnModule(Module &M) {
 
 PassPluginLibraryInfo getPassPluginInfo() {
   const auto callback = [](PassBuilder &PB) {
-    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, OptimizationLevel OL, ThinOrFullLTOPhase Phase) {
+    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, auto&&... args) {
         MPM.addPass(AMDGCNMemTrace());
       return true;
     });

--- a/lib/InjectAMDGCNFunction.cpp
+++ b/lib/InjectAMDGCNFunction.cpp
@@ -43,7 +43,7 @@ bool InjectAMDGCNFunc::runOnModule(Module &M) {
 PassPluginLibraryInfo getPassPluginInfo() {
   const auto callback = [](PassBuilder &PB) {
     PB.registerPipelineEarlySimplificationEPCallback(
-        [&](ModulePassManager &MPM, auto&&... args) {
+        [&](ModulePassManager &MPM, OptimizationLevel Level, ThinOrFullLTOPhase Phase) {
           MPM.addPass(InjectAMDGCNFunc());
           return true;
         });

--- a/lib/InjectAMDGCNFunction.cpp
+++ b/lib/InjectAMDGCNFunction.cpp
@@ -25,7 +25,7 @@ bool InjectAMDGCNFunc::runOnModule(Module &M) {
 
       // Get an IR builder. Sets the insertion point to the top of the function
       IRBuilder<> Builder(&*F.getEntryBlock().getFirstInsertionPt());
-      Function *WorkItemXIDIntrinsicFunc = Intrinsic::getDeclaration(
+      Function *WorkItemXIDIntrinsicFunc = Intrinsic::getOrInsertDeclaration(
           F.getParent(), Intrinsic::amdgcn_workitem_id_x);
 
       Value *WorkItemXValue = Builder.CreateCall(WorkItemXIDIntrinsicFunc, {});
@@ -43,7 +43,7 @@ bool InjectAMDGCNFunc::runOnModule(Module &M) {
 PassPluginLibraryInfo getPassPluginInfo() {
   const auto callback = [](PassBuilder &PB) {
     PB.registerPipelineEarlySimplificationEPCallback(
-        [&](ModulePassManager &MPM, auto) {
+        [&](ModulePassManager &MPM, OptimizationLevel OL, ThinOrFullLTOPhase Phase) {
           MPM.addPass(InjectAMDGCNFunc());
           return true;
         });

--- a/lib/InjectAMDGCNFunction.cpp
+++ b/lib/InjectAMDGCNFunction.cpp
@@ -43,7 +43,7 @@ bool InjectAMDGCNFunc::runOnModule(Module &M) {
 PassPluginLibraryInfo getPassPluginInfo() {
   const auto callback = [](PassBuilder &PB) {
     PB.registerPipelineEarlySimplificationEPCallback(
-        [&](ModulePassManager &MPM, OptimizationLevel OL, ThinOrFullLTOPhase Phase) {
+        [&](ModulePassManager &MPM, auto&&... args) {
           MPM.addPass(InjectAMDGCNFunc());
           return true;
         });

--- a/lib/InjectAMDGCNInlineASM.cpp
+++ b/lib/InjectAMDGCNInlineASM.cpp
@@ -46,7 +46,7 @@ bool InjectAMDGCNInlineASM::runOnModule(Module &M) {
 PassPluginLibraryInfo getPassPluginInfo() {
   const auto callback = [](PassBuilder &PB) {
     PB.registerPipelineEarlySimplificationEPCallback(
-        [&](ModulePassManager &MPM, auto&&... args) {
+        [&](ModulePassManager &MPM, OptimizationLevel Level, ThinOrFullLTOPhase Phase) {
           MPM.addPass(InjectAMDGCNInlineASM());
           return true;
         });

--- a/lib/InjectAMDGCNInlineASM.cpp
+++ b/lib/InjectAMDGCNInlineASM.cpp
@@ -46,7 +46,7 @@ bool InjectAMDGCNInlineASM::runOnModule(Module &M) {
 PassPluginLibraryInfo getPassPluginInfo() {
   const auto callback = [](PassBuilder &PB) {
     PB.registerPipelineEarlySimplificationEPCallback(
-        [&](ModulePassManager &MPM, OptimizationLevel OL, ThinOrFullLTOPhase Phase) {
+        [&](ModulePassManager &MPM, auto&&... args) {
           MPM.addPass(InjectAMDGCNInlineASM());
           return true;
         });

--- a/lib/InjectAMDGCNInlineASM.cpp
+++ b/lib/InjectAMDGCNInlineASM.cpp
@@ -46,7 +46,7 @@ bool InjectAMDGCNInlineASM::runOnModule(Module &M) {
 PassPluginLibraryInfo getPassPluginInfo() {
   const auto callback = [](PassBuilder &PB) {
     PB.registerPipelineEarlySimplificationEPCallback(
-        [&](ModulePassManager &MPM, auto) {
+        [&](ModulePassManager &MPM, OptimizationLevel OL, ThinOrFullLTOPhase Phase) {
           MPM.addPass(InjectAMDGCNInlineASM());
           return true;
         });

--- a/lib/InjectAMDGCNSharedMemTtrace.cpp
+++ b/lib/InjectAMDGCNSharedMemTtrace.cpp
@@ -237,7 +237,7 @@ bool InjectAMDGCNSharedMemTtrace::runOnModule(Module &M) {
 
 PassPluginLibraryInfo getPassPluginInfo() {
   const auto callback = [](PassBuilder &PB) {
-    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, OptimizationLevel OL, ThinOrFullLTOPhase Phase) {
+    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, auto&&... args) {
       MPM.addPass(InjectAMDGCNSharedMemTtrace());
       return true;
     });

--- a/lib/InjectAMDGCNSharedMemTtrace.cpp
+++ b/lib/InjectAMDGCNSharedMemTtrace.cpp
@@ -237,7 +237,7 @@ bool InjectAMDGCNSharedMemTtrace::runOnModule(Module &M) {
 
 PassPluginLibraryInfo getPassPluginInfo() {
   const auto callback = [](PassBuilder &PB) {
-    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, auto) {
+    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, OptimizationLevel OL, ThinOrFullLTOPhase Phase) {
       MPM.addPass(InjectAMDGCNSharedMemTtrace());
       return true;
     });

--- a/lib/InjectAMDGCNSharedMemTtrace.cpp
+++ b/lib/InjectAMDGCNSharedMemTtrace.cpp
@@ -237,7 +237,7 @@ bool InjectAMDGCNSharedMemTtrace::runOnModule(Module &M) {
 
 PassPluginLibraryInfo getPassPluginInfo() {
   const auto callback = [](PassBuilder &PB) {
-    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, auto&&... args) {
+    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, OptimizationLevel Level, ThinOrFullLTOPhase Phase) {
       MPM.addPass(InjectAMDGCNSharedMemTtrace());
       return true;
     });


### PR DESCRIPTION
While building on HPCFund (with latest version of LLVM) I found an adjustment was made to `registerOptimizerLastEPCallback` in the past few days. [This LLVM change](https://github.com/llvm/llvm-project/blob/b509eb7740b3300b79b90f8a43c374e28d13dc48/llvm/include/llvm/Passes/PassBuilder.h#L502-L506) adds additional parameters to the function signature which is incompatible with current implementation.

```console
/work1/amd/colramos/audacious/fork-instrument-amdgpu-kernels/lib/InjectAMDGCNFunction.cpp:46:9: error: no viable conversion from '(lambda at /work1/amd/colramos/audacious/fork-instrument-amdgpu-kernels/lib/InjectAMDGCNFunction.cpp:46:9)' to 'const std::function<void (ModulePassManager &, OptimizationLevel, ThinOrFullLTOPhase)>' (aka 'const function<void (PassManager<Module> &, llvm::OptimizationLevel, llvm::ThinOrFullLTOPhase)>')
   46 |         [&](ModulePassManager &MPM, auto) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   47 |           MPM.addPass(InjectAMDGCNFunc());
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   48 |           return true;
      |           ~~~~~~~~~~~~
   49 |         });
```

I added a variadic unroll so no matter the LLVM version being used, the lambda function should match the expected signature. 

## Full error

```console
(base) [colramos@login1 build]$ cmake -DCMAKE_C_COMPILER=/opt/rocm-6.2.1/bin/amdclang -DCMAKE_CXX_COMPILER=/opt/rocm-6.2.1/bin/amdclang++ -DLLVM_INSTALL_DIR=$WORK/.local ..
-- The C compiler identification is Clang 18.0.0
-- The CXX compiler identification is Clang 18.0.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /opt/rocm-6.2.1/bin/amdclang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /opt/rocm-6.2.1/bin/amdclang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found ZLIB: /usr/lib64/libz.so (found version "1.2.11") 
-- Found zstd: /usr/lib64/libzstd.so  
-- Found LibXml2: /usr/lib64/libxml2.so (found version "2.9.13") 
-- Found LLVM 20.0.0git
-- Using LLVMConfig.cmake in: /work1/amd/colramos/.local
LLVM STATUS:
  Definitions -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
  Includes    /work1/amd/colramos/.local/include
  Libraries   /work1/amd/colramos/.local/lib
  Targets     AArch64;AMDGPU;ARM;AVR;BPF;Hexagon;Lanai;LoongArch;Mips;MSP430;NVPTX;PowerPC;RISCV;Sparc;SystemZ;VE;WebAssembly;X86;XCore
-- Performing Test SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG
-- Performing Test SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG - Success
-- Configuring done
-- Generating done
-- Build files have been written to: /work1/amd/colramos/audacious/fork-instrument-amdgpu-kernels/build
(base) [colramos@login1 build]$ cmake --build .
[ 10%] Building CXX object lib/CMakeFiles/InjectAMDGCNFunction.dir/InjectAMDGCNFunction.cpp.o
/work1/amd/colramos/audacious/fork-instrument-amdgpu-kernels/lib/InjectAMDGCNFunction.cpp:28:55: warning: 'getDeclaration' is deprecated: Use getOrInsertDeclaration instead [-Wdeprecated-declarations]
   28 |       Function *WorkItemXIDIntrinsicFunc = Intrinsic::getDeclaration(
      |                                                       ^~~~~~~~~~~~~~
      |                                                       getOrInsertDeclaration
/work1/amd/colramos/.local/include/llvm/IR/Intrinsics.h:100:3: note: 'getDeclaration' has been explicitly marked deprecated here
  100 |   LLVM_DEPRECATED("Use getOrInsertDeclaration instead",
      |   ^
/work1/amd/colramos/.local/include/llvm/Support/Compiler.h:234:50: note: expanded from macro 'LLVM_DEPRECATED'
  234 | #define LLVM_DEPRECATED(MSG, FIX) __attribute__((deprecated(MSG, FIX)))
      |                                                  ^
/work1/amd/colramos/audacious/fork-instrument-amdgpu-kernels/lib/InjectAMDGCNFunction.cpp:46:9: error: no viable conversion from '(lambda at /work1/amd/colramos/audacious/fork-instrument-amdgpu-kernels/lib/InjectAMDGCNFunction.cpp:46:9)' to 'const std::function<void (ModulePassManager &, OptimizationLevel, ThinOrFullLTOPhase)>' (aka 'const function<void (PassManager<Module> &, llvm::OptimizationLevel, llvm::ThinOrFullLTOPhase)>')
   46 |         [&](ModulePassManager &MPM, auto) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   47 |           MPM.addPass(InjectAMDGCNFunc());
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   48 |           return true;
      |           ~~~~~~~~~~~~
   49 |         });
      |         ~
/usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/std_function.h:375:7: note: candidate constructor not viable: no known conversion from '(lambda at /work1/amd/colramos/audacious/fork-instrument-amdgpu-kernels/lib/InjectAMDGCNFunction.cpp:46:9)' to 'nullptr_t' (aka 'std::nullptr_t') for 1st argument
  375 |       function(nullptr_t) noexcept
      |       ^        ~~~~~~~~~
/usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/std_function.h:386:7: note: candidate constructor not viable: no known conversion from '(lambda at /work1/amd/colramos/audacious/fork-instrument-amdgpu-kernels/lib/InjectAMDGCNFunction.cpp:46:9)' to 'const function<void (PassManager<Module> &, OptimizationLevel, ThinOrFullLTOPhase)> &' for 1st argument
  386 |       function(const function& __x)
      |       ^        ~~~~~~~~~~~~~~~~~~~
/usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/std_function.h:404:7: note: candidate constructor not viable: no known conversion from '(lambda at /work1/amd/colramos/audacious/fork-instrument-amdgpu-kernels/lib/InjectAMDGCNFunction.cpp:46:9)' to 'function<void (PassManager<Module> &, OptimizationLevel, ThinOrFullLTOPhase)> &&' for 1st argument
  404 |       function(function&& __x) noexcept
      |       ^        ~~~~~~~~~~~~~~
/usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/std_function.h:435:2: note: candidate template ignored: requirement '_Callable<(lambda at /work1/amd/colramos/audacious/fork-instrument-amdgpu-kernels/lib/InjectAMDGCNFunction.cpp:46:9), (lambda at /work1/amd/colramos/audacious/fork-instrument-amdgpu-kernels/lib/InjectAMDGCNFunction.cpp:46:9), std::__invoke_result<(lambda at /work1/amd/colramos/audacious/fork-instrument-amdgpu-kernels/lib/InjectAMDGCNFunction.cpp:46:9) &, llvm::PassManager<llvm::Module, llvm::AnalysisManager<llvm::Module>> &, llvm::OptimizationLevel, llvm::ThinOrFullLTOPhase>>::value' was not satisfied [with _Functor = (lambda at /work1/amd/colramos/audacious/fork-instrument-amdgpu-kernels/lib/InjectAMDGCNFunction.cpp:46:9)]
  435 |         function(_Functor&& __f)
      |         ^
/work1/amd/colramos/.local/include/llvm/Passes/PassBuilder.h:484:54: note: passing argument to parameter 'C' here
  484 |                                ThinOrFullLTOPhase)> &C) {
      |                                                      ^
1 warning and 1 error generated.
gmake[2]: *** [lib/CMakeFiles/InjectAMDGCNFunction.dir/build.make:76: lib/CMakeFiles/InjectAMDGCNFunction.dir/InjectAMDGCNFunction.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:295: lib/CMakeFiles/InjectAMDGCNFunction.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
```